### PR TITLE
Add YouTube Tab Muter Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You can customize the behavior of the extension by modifying the following files
 
 1. [www.jiocinema.com](www.jiocinema.com)
 2. [www.hotstar.com](www.hotstar.com)
+3. [www.youtube.com](www.youtube.com) 
 
 ## Feedback
 

--- a/content.js
+++ b/content.js
@@ -1,10 +1,10 @@
-// Check if the current site is "hotstar" or "jiocinema"
-// Check if the current site is "hotstar" or "jiocinema"
+// Check if the current site is "hotstar" or "jiocinema" or "youtube"
 const hostname = window.location.hostname;
 const isHotstar = hostname.includes('hotstar.com');
 const isJioCinema = hostname.includes('jiocinema.com');
+const isYoutube = hostname.includes('youtube.com');
 
-if (isHotstar || isJioCinema) {
+if (isHotstar || isJioCinema || isYoutube) {
   const observer = new MutationObserver((mutationsList, observer) => {
       mutationsList.forEach((mutation) => {
         if (mutation.type === 'childList') {
@@ -22,6 +22,13 @@ if (isHotstar || isJioCinema) {
                 console.log('Hotstar Tab muted!');
               });
             }
+
+            // for Youtube
+            if (isYoutube && node.nodeType === Node.ELEMENT_NODE && node.classList.contains('ytp-ad-player-overlay-layout')) {
+              chrome.runtime.sendMessage({ action: 'muteTabVolume' }, (response) => {
+                console.log('Youtube Tab muted!');
+              });
+            }
           });
 
           mutation.removedNodes.forEach((node) => {
@@ -33,7 +40,12 @@ if (isHotstar || isJioCinema) {
             // for hotstar
             if (isHotstar && node.getAttribute && node.getAttribute('data-testid') === 'ad-details') { 
               setTimeout(() => {chrome.runtime.sendMessage({action: 'restoreTabVolume'}, (response) => console.log('HotStar Tab unmuted!'))}, 0);
-          }
+            }
+
+             // for Youtube
+            if (isYoutube && node.nodeType === Node.ELEMENT_NODE && node.classList.contains('ytp-ad-player-overlay-layout')) {
+              setTimeout(() => {chrome.runtime.sendMessage({action: 'restoreTabVolume'}, (response) => console.log('Youtube Tab unmuted!'))}, 0);
+            }
           });
         }
       });


### PR DESCRIPTION
## Description
This pull request introduces a new feature to the MuteAd Chrome extension that automatically mutes the tab volume when ads appear on YouTube. The extension now observes specific HTML elements related to YouTube ads and mutes the tab accordingly, restoring volume after the ad disappears.

## Changes Made
- Added logic in `content.js` to detect YouTube ads and mute the tab volume.
- Updated the README.md to include support for YouTube and details about the new feature.

## Related Issues
- Closes #

## How to Test
1. Pull the latest changes from this branch.
2. Load the unpacked extension in Chrome.
3. Navigate to YouTube and observe the behavior when ads appear.
4. Ensure that the tab mutes during ads and restores volume afterward.

## Checklist
- [x] Code is well-documented.
- [x] README.md is updated.
- [ ] Changes have been tested.

## Additional Notes
Please review the changes and let me know if any modifications are needed. Thank you!